### PR TITLE
Redactionpatch

### DIFF
--- a/WebContent/memorystudy/entities-by-last-month.jsp
+++ b/WebContent/memorystudy/entities-by-last-month.jsp
@@ -237,7 +237,7 @@
 
             List<String> entities = new ArrayList<>();
             if(mode==null || !mode.equals("person")) {
-                Map<Short, Map<String, Double>> es = NER.getEntities(archive.getDoc(doc), true);
+                Map<Short, Map<String, Double>> es = NER.getEntities(archive.getLuceneDoc(doc), true);
                 for (Short t : itypes) {
                     Map<String, Double> tes = es.get(t);
                     for (String str : tes.keySet())

--- a/WebContent/test/entities.jsp
+++ b/WebContent/test/entities.jsp
@@ -117,7 +117,7 @@
             if(di++>md)
                 break;
             //System.err.println("120");
-            Map<Short,Map<String,Double>> es = NER.getEntities(archive.getDoc(doc),true);
+            Map<Short,Map<String,Double>> es = NER.getEntities(archive.getLuceneDoc(doc),true);
             //System.err.println("122");
             for(Short type: inc)
                 if(!exc.contains(type)){

--- a/src/java/edu/stanford/muse/ie/ProperNounLinker.java
+++ b/src/java/edu/stanford/muse/ie/ProperNounLinker.java
@@ -691,7 +691,7 @@ public class ProperNounLinker {
 //            }
 //            archive.close();
 ////            EmailDocument ed = (EmailDocument)archive.getAllDocs().get(2);
-////            System.err.println(archive.getDoc(ed));
+////            System.err.println(archive.getLuceneDoc(ed));
 //        }catch(Exception e){
 //            e.printStackTrace();
 //        }

--- a/src/java/edu/stanford/muse/index/Archive.java
+++ b/src/java/edu/stanford/muse/index/Archive.java
@@ -828,7 +828,7 @@ public class Archive implements Serializable {
                 // Collections.sort(names);
                 // d.description = Util.join(names,
                 // Indexer.NAMES_FIELD_DELIMITER);
-                d.description = edu.stanford.muse.ner.NER.retainOnlyNames(d.description, archive.getDoc(d));
+                d.description = edu.stanford.muse.ner.NER.retainOnlyNames(d.description, archive.getLuceneDoc(d));
             }
         }
     }
@@ -1209,7 +1209,7 @@ public class Archive implements Serializable {
         return sb.toString();
     }
 
-    public org.apache.lucene.document.Document getDoc(edu.stanford.muse.index.Document d) throws IOException {
+    public org.apache.lucene.document.Document getLuceneDoc(edu.stanford.muse.index.Document d) throws IOException {
         return indexer.getDoc(d);
     }
 
@@ -1547,30 +1547,17 @@ public class Archive implements Serializable {
 
     public static void main(String[] args) {
         try {
-            String userDir = System.getProperty("user.home") + File.separator + ".muse" + File.separator + "user";
+            String userDir = System.getProperty("user.home") + File.separator + "epadd-appraisal" + File.separator + "user";
             Archive archive = SimpleSessions.readArchiveIfPresent(userDir);
             List<Document> docs = archive.getAllDocs();
-            int i=0;
             archive.assignThreadIds();
+            int i=0;
             for(Document doc: docs) {
                 EmailDocument ed = (EmailDocument)doc;
-                List<Document> threads = archive.docsWithThreadId(ed.threadID);
-                if(threads.size()>0){
-                    int numSent = 0;
-                    for(Document d: threads){
-                        EmailDocument thread = (EmailDocument)d;
-                        int sent = thread.sentOrReceived(archive.addressBook)&EmailDocument.SENT_MASK;
-                        if(sent>0)
-                            numSent++;
-                    }
-                    if(threads.size()!=numSent || threads.size()>2){
-                        System.err.println("Found a thread with "+numSent+" sent and "+threads.size()+" docs in a thread: "+ed.getSubject());
-                        break;
-                    }
-                    if(i%100 == 0)
-                        System.err.println("Scanned: "+i+" docs");
-                }
-                i++;
+                org.apache.lucene.document.Document ldoc = archive.getLuceneDoc(ed);
+                System.out.println(NER.retainOnlyNames(archive.getContents(ldoc, true), ldoc));
+                System.out.println(archive.getContents(ldoc,true));
+                if(i++>10)break;
             }
         } catch (Exception e) {
             e.printStackTrace();

--- a/src/java/edu/stanford/muse/index/Archive.java
+++ b/src/java/edu/stanford/muse/index/Archive.java
@@ -828,7 +828,7 @@ public class Archive implements Serializable {
                 // Collections.sort(names);
                 // d.description = Util.join(names,
                 // Indexer.NAMES_FIELD_DELIMITER);
-                d.description = edu.stanford.muse.ner.NER.retainOnlyNames(d.description, archive.getLuceneDoc(d));
+                d.description = edu.stanford.muse.ner.NER.retainOnlyNames(d.description, archive.getLuceneDoc(d), false);
             }
         }
     }
@@ -916,14 +916,14 @@ public class Archive implements Serializable {
                     doc.removeFields("body_original");
 
                     if (text != null) {
-                        String redacted_text = edu.stanford.muse.ner.NER.retainOnlyNames(text, doc);
+                        String redacted_text = edu.stanford.muse.ner.NER.retainOnlyNames(text, doc, true);
                         doc.add(new Field("body", redacted_text, Indexer.full_ft));
                         //this uses standard analyzer, not stemming because redacted bodys only have names.
                     }
                     String title = doc.get("title");
                     doc.removeFields("title");
                     if (title != null) {
-                        String redacted_title = edu.stanford.muse.ner.NER.retainOnlyNames(text, doc);
+                        String redacted_title = edu.stanford.muse.ner.NER.retainOnlyNames(title, doc, false);
                         doc.add(new Field("title", redacted_title, Indexer.full_ft));
                     }
                 }
@@ -1555,9 +1555,10 @@ public class Archive implements Serializable {
             for(Document doc: docs) {
                 EmailDocument ed = (EmailDocument)doc;
                 org.apache.lucene.document.Document ldoc = archive.getLuceneDoc(ed);
-                System.out.println(NER.retainOnlyNames(archive.getContents(ldoc, true), ldoc));
-                System.out.println(archive.getContents(ldoc,true));
-                if(i++>10)break;
+                //System.out.println(NER.getNameOffsets(ldoc, false));
+                System.out.println(NER.retainOnlyNames(ldoc.get("title"), ldoc, false));
+                System.out.println(ldoc.get("title"));
+                if(i++>1000)break;
             }
         } catch (Exception e) {
             e.printStackTrace();

--- a/src/java/edu/stanford/muse/index/Indexer.java
+++ b/src/java/edu/stanford/muse/index/Indexer.java
@@ -1488,7 +1488,7 @@ public class Indexer implements StatusProvider, java.io.Serializable {
 				//				if (ed.languages == null)
 				//				{
 				//					// extract languages for the doc from the index and store it in the document, so we don't have to compute it again
-				//					String lang = getDoc(docId).getFieldable("languages").stringValue();
+				//					String lang = getLuceneDoc(docId).getFieldable("languages").stringValue();
 				//					StringTokenizer st = new StringTokenizer(lang, ",");
 				//					Set<String> langs = new LinkedHashSet<String>();
 				//					while (st.hasMoreTokens())

--- a/src/java/edu/stanford/muse/memory/MemoryStudy.java
+++ b/src/java/edu/stanford/muse/memory/MemoryStudy.java
@@ -261,7 +261,7 @@ public class MemoryStudy implements Serializable{
 
             List<String> entities = new ArrayList<>();
             if(!personTest) {
-                Map<Short, Map<String, Double>> es = edu.stanford.muse.ner.NER.getEntities(archive.getDoc(doc), true);
+                Map<Short, Map<String, Double>> es = edu.stanford.muse.ner.NER.getEntities(archive.getLuceneDoc(doc), true);
                 for (Short t : itypes) {
                     Map<String, Double> tes = es.get(t);
                     for (String str : tes.keySet())

--- a/src/java/edu/stanford/muse/ner/NER.java
+++ b/src/java/edu/stanford/muse/ner/NER.java
@@ -511,8 +511,9 @@ public class NER implements StatusProvider {
 	}
 
     //retains only filtered entities
-	public static String retainOnlyNames(String text, org.apache.lucene.document.Document doc) {
-        List<Triple<String,Integer, Integer>> offsets = edu.stanford.muse.ner.NER.getNameOffsets(doc, true);
+    //body boolean marked if the retain names is carried out over body or title
+	public static String retainOnlyNames(String text, org.apache.lucene.document.Document doc, boolean body) {
+        List<Triple<String,Integer, Integer>> offsets = edu.stanford.muse.ner.NER.getNameOffsets(doc, body);
         if (offsets == null) {
 		    //mask the whole content
             offsets = new ArrayList<>();
@@ -526,22 +527,8 @@ public class NER implements StatusProvider {
 
 		//make sure the offsets are in order, i.e. the end offsets are in increasing order
 		arrangeOffsets(offsets);
-        List<String> people = Archive.getEntitiesInLuceneDoc(doc, NER.EPER, true);
-        List<String> orgs = Archive.getEntitiesInLuceneDoc(doc, NER.EORG, true);
-        List<String> places = Archive.getEntitiesInLuceneDoc(doc, NER.ELOC, true);
-        Set<String> allEntities = new LinkedHashSet<>();
-        if (people!=null)
-            allEntities.addAll(people);
-        if (orgs!=null)
-            allEntities.addAll(orgs);
-        if (places!=null)
-            allEntities.addAll(places);
 
         for (Triple<String, Integer, Integer> t : offsets) {
-            String entity = t.first;
-            if(!allEntities.contains(entity))
-                continue;
-
           	int begin_pos = t.second();
 			int end_pos = t.third();
 			if (begin_pos > len || end_pos > len) {

--- a/src/java/edu/stanford/muse/ner/NER.java
+++ b/src/java/edu/stanford/muse/ner/NER.java
@@ -190,7 +190,7 @@ public class NER implements StatusProvider {
             Util.aggressiveWarn("Archive/doc is null to retrieve offsets", -1);
             return null;
         }
-        org.apache.lucene.document.Document ldoc = archive.getDoc(doc);
+        org.apache.lucene.document.Document ldoc = archive.getLuceneDoc(doc);
         return getNameOffsets(ldoc, body);
     }
 
@@ -353,7 +353,7 @@ public class NER implements StatusProvider {
 
     public static Map<Short,Map<String,Double>> getEntities(Document doc, boolean body, Archive archive) {
         try {
-            org.apache.lucene.document.Document ldoc = archive.getDoc(doc);
+            org.apache.lucene.document.Document ldoc = archive.getLuceneDoc(doc);
             return getEntities(ldoc, body);
         } catch(IOException e){
             Util.print_exception("!!Exception while accessing named entities in the doc", e, log);
@@ -386,7 +386,7 @@ public class NER implements StatusProvider {
 		for (Document doc : docs) {
 			long st1 = System.currentTimeMillis();
 			long st = System.currentTimeMillis();
-			org.apache.lucene.document.Document ldoc = archive.getDoc(doc);
+			org.apache.lucene.document.Document ldoc = archive.getLuceneDoc(doc);
 			//pass the lucene doc instead of muse doc, else a major performance penalty
 			//do not recognise names in original content and content separately
 			//Its possible to improve the performance further by using linear kernel

--- a/src/java/edu/stanford/muse/ner/dictionary/EnglishDictionary.java
+++ b/src/java/edu/stanford/muse/ner/dictionary/EnglishDictionary.java
@@ -217,7 +217,7 @@ public class EnglishDictionary {
             return abbDict;
         abbDict = LinkedHashMultimap.create();
         try{
-            BufferedReader br = new BufferedReader(new InputStreamReader(EnglishDictionary.class.getClassLoader().getResourceAsStream(abbFile)));
+            BufferedReader br = new BufferedReader(new InputStreamReader(Config.getResourceAsStream(abbFile)));
             String line;
             while((line=br.readLine())!=null){
                 if(line.startsWith("#"))
@@ -308,5 +308,6 @@ public class EnglishDictionary {
     public static void main(String[] args){
         //testPlurals();
         getAbbreviations();
+        getDict();
     }
 }

--- a/src/java/edu/stanford/muse/ner/model/SequenceModel.java
+++ b/src/java/edu/stanford/muse/ner/model/SequenceModel.java
@@ -525,32 +525,31 @@ public class SequenceModel implements NERModel, Serializable {
         return mTypes;
     }
 
-    public Pair<Map<Short,Map<String,Double>>, List<Triple<String, Integer, Integer>>> find (String content){
-        Map<Short, Map<String,Double>> maps = new LinkedHashMap<>();
-        List<Triple<String,Integer,Integer>> offsets = new ArrayList<>();
+    public Pair<Map<Short,Map<String,Double>>, List<Triple<String, Integer, Integer>>> find (String content) {
+        Map<Short, Map<String, Double>> maps = new LinkedHashMap<>();
+        List<Triple<String, Integer, Integer>> offsets = new ArrayList<>();
 
-        for(Short at: FeatureDictionary.allTypes)
+        for (Short at : FeatureDictionary.allTypes)
             maps.put(at, new LinkedHashMap<>());
 
-        String[] sents = NLPUtils.tokeniseSentence(content);
-        for(String sent: sents) {
-            List<Triple<String, Integer, Integer>> toks = tokenizer.tokenize(sent, false);
-            for (Triple<String, Integer, Integer> t : toks) {
-                //this should never happen
-                if(t==null || t.first == null)
-                    continue;
+        //Do not segment on sentences here, that will mess the token offsets returned by the Tokenizer
+        //String[] sents = NLPUtils.tokeniseSentence(content);
+        List<Triple<String, Integer, Integer>> toks = tokenizer.tokenize(content, false);
+        for (Triple<String, Integer, Integer> t : toks) {
+            //this should never happen
+            if (t == null || t.first == null)
+                continue;
 
-                Map<String,Pair<Short,Double>> entities = seqLabel(t.getFirst());
-                for(String e: entities.keySet()){
-                    Pair<Short,Double> p = entities.get(e);
-                    //A new type is assigned to some words, which is of value -2
-                    if(p.first<0)
-                        continue;
-                    if(p.first!=FeatureDictionary.OTHER) {
-                        //System.err.println("Segment: "+t.first+", "+t.second+", "+t.third+", "+sent.substring(t.second,t.third));
-                        offsets.add(new Triple<>(e, t.second + t.first.indexOf(e), t.second + t.first.indexOf(e) + e.length()));
-                        maps.get(p.getFirst()).put(e, p.second);
-                    }
+            Map<String, Pair<Short, Double>> entities = seqLabel(t.getFirst());
+            for (String e : entities.keySet()) {
+                Pair<Short, Double> p = entities.get(e);
+                //A new type is assigned to some words, which is of value -2
+                if (p.first < 0)
+                    continue;
+                if (p.first != FeatureDictionary.OTHER) {
+                    //System.err.println("Segment: "+t.first+", "+t.second+", "+t.third+", "+sent.substring(t.second,t.third));
+                    offsets.add(new Triple<>(e, t.second + t.first.indexOf(e), t.second + t.first.indexOf(e) + e.length()));
+                    maps.get(p.getFirst()).put(e, p.second);
                 }
             }
         }
@@ -852,9 +851,10 @@ public class SequenceModel implements NERModel, Serializable {
         try{nerModel = SequenceModel.loadModel(modelFile);}
         catch(IOException e){e.printStackTrace();}
         printMemoryUsage();
-        if(nerModel == null)
+        if(nerModel == null) {
+            System.out.println("Training a NER model");
             nerModel = train();
-
+        }
         if (nerModel != null) {
             System.out.println(nerModel.find("We are traveling to Vietnam the next summer and will come to New York (NYC) soon"));
             System.out.println(nerModel.find("Mr. HariPrasad was present."));

--- a/src/java/edu/stanford/muse/ner/tokenizer/CICTokenizer.java
+++ b/src/java/edu/stanford/muse/ner/tokenizer/CICTokenizer.java
@@ -330,7 +330,21 @@ public class CICTokenizer implements Tokenizer, Serializable {
                         "originally agreed not to run for a second term in Congress, and because his opposition to the Mexican–American War was unpopular among Illinois " +
                         "voters, Lincoln returned to Springfield and resumed his successful law practice. Reentering politics in 1854, he became a leader in building the " +
                         "new Republican Party, which had a statewide majority in Illinois. In 1858, while taking part in a series of highly publicized debates with his " +
-                        "opponent and rival, Democrat Stephen A. Douglas, Lincoln spoke out against the expansion of slavery, but lost the U.S. Senate race to Douglas."
+                        "opponent and rival, Democrat Stephen A. Douglas, Lincoln spoke out against the expansion of slavery, but lost the U.S. Senate race to Douglas.",
+                "The President's words on health care reform were phenomenal. I pray he could get them passed in Congress.\n" +
+                        "\n" +
+                        "Thought you might want to consider some live example during your state of the state on liability reform. Maybe a doc that has had to quit like an OB/GYN to flash up on the screen asking you to resolve the problem so pregnant women can get care when they need it most.\n" +
+                        "\n" +
+                        "Your state of the state will be key to this entire debate.\n" +
+                        "\n" +
+                        "Thanks,\n" +
+                        "Sandy ",
+                "HERE IN HILLSBOROUGH COUNTY ARE COUNTING ON YOUR GOOD, WISE SELECTION APPOINTEE FOR THE POST OF SUPERVISOR OF ELECTIONS.\n" +
+                        "YOUR GREAT DECISION WILL SAVE US FROM A \n" +
+                        "WEST PALM BEACH REPLICA HERE.\n" +
+                        "PLEASE OPEN THIS ATTACHMENT.\n" +
+                        "YOUR FRIEND,\n" +
+                        "GLADYS LEVY"
         };
         String[][] tokens = new String[][]{
                 new String[]{"Information Retrieval","Christopher Manning"},
@@ -382,7 +396,9 @@ public class CICTokenizer implements Tokenizer, Serializable {
                 new String[]{"Abraham Lincoln", "United States", "Lincoln", "Civil War", "Union", "Hodgenville", "Kentucky", "Indiana", "Illinois",
                         "Whig Party", "Illinois House of Representatives", "United States House of Representatives", "Congress", "Mexican–American War", "Springfield",
                         "Republican Party","Democrat Stephen A. Douglas","U.S. Senate","Douglas"
-                }
+                },
+                new String[]{},
+                new String[]{}
         };
         for(int ci=0;ci<contents.length;ci++){
             String content = contents[ci];
@@ -390,7 +406,7 @@ public class CICTokenizer implements Tokenizer, Serializable {
             //want to specifically test person names tokenizer for index 3.
             Set<String> cics = tokenizer.tokenizeWithoutOffsets(content, ci == 3 ? true : false);
             List<Triple<String,Integer,Integer>> offs = tokenizer.tokenize(content, ci == 3 ? true : false);
-            
+
             for(Triple<String,Integer,Integer> off: offs)
                 if(!content.substring(off.second, off.third).equals(off.first))
                     System.err.println("Improper offset for \""+content+"\" found: "+content.substring(off.second,off.third)+"; offset: "+off);
@@ -401,6 +417,8 @@ public class CICTokenizer implements Tokenizer, Serializable {
                     missing = true;
                     System.err.println("Missing: "+cic);
                 }
+            System.out.println("Content: "+content);
+            System.out.println(offs);
             if(cics.size()!=ts.size() || missing) {
                 String str = "------------\n" +
                              "Test failed!\n" +

--- a/src/java/edu/stanford/muse/test/LuceneQueryBenchmark.java
+++ b/src/java/edu/stanford/muse/test/LuceneQueryBenchmark.java
@@ -33,7 +33,7 @@ public class LuceneQueryBenchmark {
         for(int i=0;i<numTest;i++) {
             st = System.currentTimeMillis();
             Document doc = docs.get(rand.nextInt(docs.size()));
-            try {archive.getDoc(doc);} catch(IOException e){}
+            try {archive.getLuceneDoc(doc);} catch(IOException e){}
             searchTime += System.currentTimeMillis()-st;
         }
         System.out.println(


### PR DESCRIPTION
The SequenceModel.find() method calls Tokenizer over a segmented sentence therefore the offsets of the tokens are wrt to only the sentence and not the entire content.
Fixed this minor issue by calling Tokenizer with the entire content at once.
Fixed a title redaction bug.
